### PR TITLE
Fix nightwatch tests on Windows (close #26)

### DIFF
--- a/app/templates/ecommerce/index.html
+++ b/app/templates/ecommerce/index.html
@@ -16,12 +16,12 @@
         };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
         n.src=w;g.parentNode.insertBefore(n,g)}}(window, document, "script", "{% static 'ecommerce/js/sp.js' %}", "snowplow"));
 
-        window.snowplow('newTracker', 'spmicro', '0.0.0.0:9090', { // Initialise a tracker
+        window.snowplow('newTracker', 'spmicro', '127.0.0.1:9090', { // Initialise a tracker
             encodeBase64: false,
             appId: 'sh0pspr33',
             platform: "web",
             discoverRootDomain: true,
-            eventMethod: "beacon",
+            eventMethod: 'beacon'
         });
 
         window.snowplow('setUserId', 'tester');

--- a/app/templates/ecommerce/shop.html
+++ b/app/templates/ecommerce/shop.html
@@ -28,12 +28,12 @@
         };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
         n.src=w;g.parentNode.insertBefore(n,g)}}(window, document, "script", "{% static 'ecommerce/js/sp.js' %}", "snowplow"));
 
-        window.snowplow('newTracker', 'spmicro', '0.0.0.0:9090', { // Initialise a tracker
+        window.snowplow('newTracker', 'spmicro', '127.0.0.1:9090', { // Initialise a tracker
             encodeBase64: false,
             appId: 'sh0pspr33',
-            platform: "web",
+            platform: 'web',
             discoverRootDomain: true,
-            eventMethod: "beacon",
+            eventMethod: 'beacon'
         });
 
         window.snowplow('setUserId', 'tester');

--- a/app/templates/ecommerce/thanks.html
+++ b/app/templates/ecommerce/thanks.html
@@ -16,12 +16,12 @@
         };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
         n.src=w;g.parentNode.insertBefore(n,g)}}(window, document, "script", "{% static 'ecommerce/js/sp.js' %}", "snowplow"));
 
-        window.snowplow('newTracker', 'spmicro', '0.0.0.0:9090', { // Initialise a tracker
+        window.snowplow('newTracker', 'spmicro', '127.0.0.1:9090', { // Initialise a tracker
             encodeBase64: false,
             appId: 'sh0pspr33',
-            platform: "web",
+            platform: 'web',
             discoverRootDomain: true,
-            eventMethod: "beacon",
+            eventMethod: 'beacon'
         });
 
         window.snowplow('setUserId', 'tester');

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
         "description": "Examples of how to apply Snowplow Micro to popular test strategies",
         "private": true,
         "scripts": {
-                "test": "cd testing; nightwatch && cypress run --config-file false",
-                "test:nightwatch": "cd testing; nightwatch",
+                "test": "cd testing && (nightwatch && cypress run --config-file false)",
+                "test:nightwatch": "cd testing && nightwatch",
                 "cypress:open": "cd testing && cypress open --config-file false",
                 "cypress:run": "cd testing && cypress run --config-file false",
                 "cy-micro:pair-run": "cd testing && npm run cypress:run -- --spec \"**/integration/*$PAIR_PATTERN*app_spec.js\"",

--- a/testing/nightwatch.conf.js
+++ b/testing/nightwatch.conf.js
@@ -18,7 +18,7 @@ module.exports = {
 
     "webdriver": {
         "start_process": true,
-        "server_path": "../node_modules/.bin/chromedriver",
+        "server_path": require('chromedriver').path,
         "port": 9515
     },
 
@@ -35,7 +35,7 @@ module.exports = {
             "desiredCapabilities": {
                 "browserName": "chrome",
                 'chromeOptions': {
-                    'args': ['--headless']
+                    'args': ['headless', "window-size=1280,1024","force-device-scale-factor=1"]
                 }
             }
         }


### PR DESCRIPTION
Currently npm test:nightwatch doesn't run successfully on Windows.

There is also a flaky test due to the Chrome resolution when running in headless mode, the resolution should be fixed.